### PR TITLE
Fix typo on mactrack_functions.php

### DIFF
--- a/lib/mactrack_functions.php
+++ b/lib/mactrack_functions.php
@@ -1074,6 +1074,7 @@ function get_base_dot1dTpFdbEntry_ports($site, &$device, &$ifInterfaces, $snmp_r
 			if ($port_info == 1) {
 				$ports_active++;
 			}
+			}
 			$ports_total++;
 		}
 


### PR DESCRIPTION
dumb typo from this commit 8a5577829327b222df47070c2012eb02e5faa8da
Causing unexpected EOF and Cacti to disable Mactrack.