### PR TITLE
Fix for issue #65: Extra separator on mac address

### DIFF
--- a/lib/mactrack_functions.php
+++ b/lib/mactrack_functions.php
@@ -1811,7 +1811,7 @@ function xform_mac_address($mac_address) {
 		}else{ /* return is hex */
 			$mac = "";
 			for ($j = 0; $j < strlen($mac_address); $j++) {
-				$mac .= bin2hex($mac_address[$j]) . read_config_option("mt_mac_delim");
+				$mac .= bin2hex($mac_address[$j]) . ($j == strlen($mac_address) ? '' : read_config_option("mt_mac_delim"));
 			}
 			$mac_address = $mac;
 		}


### PR DESCRIPTION
Removes the trailing delmiter from the mac address as seen in issue #65 