### PR TITLE
Fix #82

### DIFF
--- a/includes/database.php
+++ b/includes/database.php
@@ -25,6 +25,14 @@
 function mactrack_database_upgrade() {
 	global $database_default;
 
+	if (!mactrack_db_key_exists('mac_track_devices', 'device_id_UNIQUE')) {
+		db_execute('ALTER TABLE `mac_track_devices` ADD UNIQUE INDEX `device_id_UNIQUE` (`device_id`);');
+	}
+	
+	if (!mactrack_db_key_exists('mac_track_device_types', 'device_type_id_UNIQUE')) {
+		db_execute('ALTER TABLE `mac_track_device_types` ADD UNIQUE INDEX `device_type_id_UNIQUE` (`device_type_id`);');
+	}	
+
 	mactrack_add_column('mac_track_interfaces',
 		'ifHighSpeed',
 		"ALTER TABLE `mac_track_interfaces` ADD COLUMN `ifHighSpeed` int(10) unsigned NOT NULL default '0' AFTER `ifSpeed`");


### PR DESCRIPTION
mac_track_devices and mac_track_device_types don't have unique index on device_id and device_type_id columns. When you edit any device type and change any of  (`sysDescr_match`, `sysObjectID_match`, `device_type') this will dubl row in table. Need add unique index OR don't use device_type_id on save sql
https://github.com/Cacti/plugin_mactrack/blob/77bff4acf78386854ff5f1705b159ce98d2ab115/mactrack_device_types.php#L167

Creating an index is better.

Also this fix #82 