### PR TITLE
fix dns resolving timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 --- develop ---
 
 * issue#206: Improve PHP8.x - undefined variables, array keys, ... 
+* issue#198: Better control for DNS resolving process
 
 --- 4.6 ---
 

--- a/mactrack_devices.php
+++ b/mactrack_devices.php
@@ -880,9 +880,7 @@ function mactrack_device_edit() {
 
 					$old_device = $device;
 
-// tady
  					if (!valid_snmp_device($device)) {
-//					if ($snmp_system == '') {
 						print "<span style='color: #ff0000; font-weight: bold;'>SNMP error</span>\n";
 					} else {
 						// snmp readstring is incorrect but mactrack found correct values in any snmp set

--- a/mactrack_resolver.php
+++ b/mactrack_resolver.php
@@ -36,6 +36,9 @@ if (is_numeric($max_run_duration)) {
 	/* let PHP a 5 minutes less than the rerun frequency */
 	$max_run_duration = ($max_run_duration * 60) - 300;
 	ini_set('max_execution_time', $max_run_duration);
+} else {
+	$max_run_duration = 3300;
+	ini_set('max_execution_time', $max_run_duration);
 }
 
 /* establish constants */

--- a/mactrack_resolver.php
+++ b/mactrack_resolver.php
@@ -98,7 +98,7 @@ if (read_config_option('mt_reverse_dns') == 'on') {
 }
 
 /* silently end if the registered process is still running  */
-if (!register_process_start('mactrack_resolver', 'master', 0, 86400)) {
+if (!register_process_start('mactrack_resolver', 'master', 0, $max_run_duration-300)) {
 	print "FATAL: Detected an already running process." . PHP_EOL;
 	exit(0);
 }


### PR DESCRIPTION
finish resolving few minutes before php kills script. In code is:

if (is_numeric($max_run_duration)) {
            /* let PHP a 5 minutes less than the rerun frequency */
            $max_run_duration = ($max_run_duration * 60) - 300;
            ini_set('max_execution_time', $max_run_duration);
}

So I want to end script before this timeout