### PR TITLE
fix PHP deprecated

### DIFF
--- a/mactrack_view_macs.php
+++ b/mactrack_view_macs.php
@@ -455,7 +455,7 @@ function mactrack_view_export_macs() {
 	}
 }
 
-function mactrack_view_get_mac_records(&$sql_where, $apply_limits = true, $rows) {
+function mactrack_view_get_mac_records(&$sql_where, $rows, $apply_limits = true) {
 	/* form the 'where' clause for our main sql query */
 	if (get_request_var('mac_filter') != '') {
 
@@ -665,7 +665,7 @@ function mactrack_view_macs() {
 		$rows = get_request_var('rows');
 	}
 
-	$port_results = mactrack_view_get_mac_records($sql_where, true, $rows);
+	$port_results = mactrack_view_get_mac_records($sql_where, $rows, true);
 
 	/* prevent table scans, either a device or site must be selected */
 	if ($sql_where == '') {
@@ -871,7 +871,7 @@ function mactrack_view_aggregated_macs() {
 		$rows = get_request_var('rows');
 	}
 
-	$port_results = mactrack_view_get_mac_records($sql_where, true, $rows);
+	$port_results = mactrack_view_get_mac_records($sql_where, $rows, true);
 
 	/* prevent table scans, either a device or site must be selected */
 	if ($sql_where == '') {


### PR DESCRIPTION
Fix PHP deprecated from #255 
PHP Deprecated:  Optional parameter $apply_limits declared before required parameter $rows is implicitly treated as a required parameter in ./mactrack_view_macs.php on line 458
No syntax errors detected in ./mactrack_view_macs.php