### PR TITLE
refactor: extract mactrack_typed_filter_clause and mactrack_normalize_mac

### DIFF
--- a/lib/mactrack_functions.php
+++ b/lib/mactrack_functions.php
@@ -3763,6 +3763,72 @@ function mactrack_arr_key($array, $key, $default = '') {
  * aabb.ccdd.eeff
  */
 
+/**
+ * Strip delimiter characters from a MAC address string.
+ *
+ * @param  string $input MAC address in any common format
+ *
+ * @return string Bare hex MAC with no delimiters
+ */
+function mactrack_normalize_mac($input) {
+	return str_replace([':','-','.'], '', $input);
+}
+
+/**
+ * Append a typed filter clause to a WHERE string.
+ *
+ * Supports: 1=none, 2=matches, 3=contains, 4=begins-with,
+ * 5=not-contains, 6=not-begins-with, 7=is-null, 8=is-not-null.
+ *
+ * @param  string $column     The SQL column name to filter on
+ * @param  string $value      The filter value from the request
+ * @param  string $type_id    The filter type identifier (1-8)
+ * @param  string &$sql_where The WHERE clause to append to
+ *
+ * @return void
+ */
+function mactrack_typed_filter_clause($column, $value, $type_id, &$sql_where) {
+	switch ($type_id) {
+		case '1': // do not filter
+			break;
+		case '2': // matches
+			$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
+				" $column = " . db_qstr($value);
+
+			break;
+		case '3': // contains
+			$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
+				" $column LIKE " . db_qstr('%' . $value . '%');
+
+			break;
+		case '4': // begins with
+			$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
+				" $column LIKE " . db_qstr($value . '%');
+
+			break;
+		case '5': // does not contain
+			$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
+				" $column NOT LIKE " . db_qstr('%' . $value . '%');
+
+			break;
+		case '6': // does not begin with
+			$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
+				" $column NOT LIKE " . db_qstr($value . '%');
+
+			break;
+		case '7': // is null
+			$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
+				" $column = \"\"";
+
+			break;
+		case '8': // is not null
+			$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
+				" $column != \"\"";
+
+			break;
+	}
+}
+
 function mactrack_format_mac($mac) {
 	if (is_null($mac) || strlen($mac) < 10) {
 		return $mac;

--- a/mactrack_view_arp.php
+++ b/mactrack_view_arp.php
@@ -142,77 +142,12 @@ function mactrack_view_export_ips() {
 function mactrack_view_get_ip_records(&$sql_where, $apply_limits = true, $rows) {
 	// form the 'where' clause for our main sql query
 	if (get_request_var('mac_filter') != '') {
-		$mac_filter = str_replace(':', '', get_request_var('mac_filter'));
-		$mac_filter = str_replace('-', '', $mac_filter);
-		$mac_filter = str_replace('.', '', $mac_filter);
-
-		switch (get_request_var('mac_filter_type_id')) {
-			case '1': // do not filter
-				break;
-			case '2': // matches
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.mac_address = ' . db_qstr($mac_filter);
-
-				break;
-			case '3': // contains
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.mac_address LIKE ' . db_qstr('%' . $mac_filter . '%');
-
-				break;
-			case '4': // begins with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.mac_address LIKE ' . db_qstr($mac_filter . '%');
-
-				break;
-			case '5': // does not contain
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.mac_address NOT LIKE ' . db_qstr('%' . $mac_filter . '%');
-
-				break;
-			case '6': // does not begin with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.mac_address NOT LIKE ' . db_qstr($mac_filter . '%');
-		}
+		$mac_filter = mactrack_normalize_mac(get_request_var('mac_filter'));
+		mactrack_typed_filter_clause('mti.mac_address', $mac_filter, get_request_var('mac_filter_type_id'), $sql_where);
 	}
 
 	if ((get_request_var('ip_filter') != '') || (get_request_var('ip_filter_type_id') > 6)) {
-		switch (get_request_var('ip_filter_type_id')) {
-			case '1': // do not filter
-				break;
-			case '2': // matches
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.ip_address = ' . db_qstr(get_request_var('ip_filter'));
-
-				break;
-			case '3': // contains
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.ip_address LIKE ' . db_qstr('%' . get_request_var('ip_filter') . '%');
-
-				break;
-			case '4': // begins with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.ip_address LIKE ' . db_qstr(get_request_var('ip_filter') . '%');
-
-				break;
-			case '5': // does not contain
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.ip_address NOT LIKE ' . db_qstr('%' . get_request_var('ip_filter') . '%');
-
-				break;
-			case '6': // does not begin with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.ip_address NOT LIKE ' . db_qstr(get_request_var('ip_filter') . '%');
-
-				break;
-			case '7': // is null
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.ip_address = ""';
-
-				break;
-			case '8': // is not null
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') .
-					' mti.ip_address != ""';
-		}
+		mactrack_typed_filter_clause('mti.ip_address', get_request_var('ip_filter'), get_request_var('ip_filter_type_id'), $sql_where);
 	}
 
 	if (get_request_var('filter') != '') {

--- a/mactrack_view_dot1x.php
+++ b/mactrack_view_dot1x.php
@@ -184,104 +184,16 @@ function mactrack_view_get_dot1x_records(&$sql_where, $apply_limits = true, $row
 
 	// form the 'where' clause for our main sql query
 	if (get_request_var('mac_filter') != '') {
-		$mac_filter = str_replace(':', '', get_request_var('mac_filter'));
-		$mac_filter = str_replace('-', '', $mac_filter);
-		$mac_filter = str_replace('.', '', $mac_filter);
-
-		switch (get_request_var('mac_filter_type_id')) {
-			case '1': // do not filter
-				break;
-			case '2': // matches
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.mac_address = ' . db_qstr($mac_filter);
-
-				break;
-			case '3': // contains
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.mac_address LIKE ' . db_qstr('%' . $mac_filter . '%');
-
-				break;
-			case '4': // begins with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.mac_address LIKE ' . db_qstr($mac_filter . '%');
-
-				break;
-			case '5': // does not contain
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.mac_address NOT LIKE ' . db_qstr('%' . $mac_filter . '%');
-
-				break;
-			case '6': // does not begin with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.mac_address NOT LIKE ' . db_qstr($mac_filter . '%');
-
-				break;
-		}
+		$mac_filter = mactrack_normalize_mac(get_request_var('mac_filter'));
+		mactrack_typed_filter_clause('mtd.mac_address', $mac_filter, get_request_var('mac_filter_type_id'), $sql_where);
 	}
 
 	if ((get_request_var('ip_filter') != '') || (get_request_var('ip_filter_type_id') > 6)) {
-		switch (get_request_var('ip_filter_type_id')) {
-			case '1': // do not filter
-				break;
-			case '2': // matches
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.ip_address = ' . db_qstr(get_request_var('ip_filter'));
-
-				break;
-			case '3': // contains
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.ip_address LIKE ' . db_qstr('%' . get_request_var('ip_filter') . '%');
-
-				break;
-			case '4': // begins with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.ip_address LIKE ' . db_qstr(get_request_var('ip_filter') . '%');
-
-				break;
-			case '5': // does not contain
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.ip_address NOT LIKE ' . db_qstr('%' . get_request_var('ip_filter') . '%');
-
-				break;
-			case '6': // does not begin with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.ip_address NOT LIKE ' . db_qstr(get_request_var('ip_filter') . '%');
-
-				break;
-			case '7': // is null
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.ip_address = ""';
-
-				break;
-			case '8': // is not null
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtd.ip_address != ""';
-
-				break;
-		}
+		mactrack_typed_filter_clause('mtd.ip_address', get_request_var('ip_filter'), get_request_var('ip_filter_type_id'), $sql_where);
 	}
 
 	if ((get_request_var('port_name_filter') != '') || (get_request_var('port_name_filter_type_id') > 6)) {
-		switch (get_request_var('port_name_filter_type_id')) {
-			case '1': // do not filter
-				break;
-			case '2': // matches
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mti.ifName = ' . db_qstr(get_request_var('port_name_filter'));
-
-				break;
-			case '3': // contains
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mti.ifName LIKE ' . db_qstr('%' . get_request_var('port_name_filter') . '%');
-
-				break;
-			case '4': // begins with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mti.ifName LIKE ' . db_qstr(get_request_var('port_name_filter') . '%');
-
-				break;
-			case '5': // does not contain
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mti.ifName NOT LIKE ' . db_qstr('%' . get_request_var('port_name_filter') . '%');
-
-				break;
-			case '6': // does not begin with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mti.ifName NOT LIKE ' . db_qstr(get_request_var('port_name_filter') . '%');
-
-				break;
-			case '7': // is null
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mti.ifName = ""';
-
-				break;
-			case '8': // is not null
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mti.ifName != ""';
-
-				break;
-		}
+		mactrack_typed_filter_clause('mti.ifName', get_request_var('port_name_filter'), get_request_var('port_name_filter_type_id'), $sql_where);
 	}
 
 	if (get_request_var('filter') != '') {

--- a/mactrack_view_macs.php
+++ b/mactrack_view_macs.php
@@ -463,100 +463,16 @@ function mactrack_view_export_macs() {
 function mactrack_view_get_mac_records(&$sql_where, $rows, $apply_limits = true) {
 	// form the 'where' clause for our main sql query
 	if (get_request_var('mac_filter') != '') {
-		$mac_filter = str_replace(':', '', get_request_var('mac_filter'));
-		$mac_filter = str_replace('-', '', $mac_filter);
-		$mac_filter = str_replace('.', '', $mac_filter);
-
-		switch (get_request_var('mac_filter_type_id')) {
-			case '1': // do not filter
-				break;
-			case '2': // matches
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.mac_address = ' . db_qstr($mac_filter);
-
-				break;
-			case '3': // contains
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.mac_address LIKE ' . db_qstr('%' . $mac_filter . '%');
-
-				break;
-			case '4': // begins with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.mac_address LIKE ' . db_qstr($mac_filter . '%');
-
-				break;
-			case '5': // does not contain
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.mac_address NOT LIKE ' . db_qstr('%' . $mac_filter . '%');
-
-				break;
-			case '6': // does not begin with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.mac_address NOT LIKE ' . db_qstr($mac_filter . '%');
-		}
+		$mac_filter = mactrack_normalize_mac(get_request_var('mac_filter'));
+		mactrack_typed_filter_clause('mtp.mac_address', $mac_filter, get_request_var('mac_filter_type_id'), $sql_where);
 	}
 
 	if ((get_request_var('ip_filter') != '') || (get_request_var('ip_filter_type_id') > 6)) {
-		switch (get_request_var('ip_filter_type_id')) {
-			case '1': // do not filter
-				break;
-			case '2': // matches
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.ip_address = ' . db_qstr(get_request_var('ip_filter'));
-
-				break;
-			case '3': // contains
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.ip_address LIKE ' . db_qstr('%' . get_request_var('ip_filter') . '%');
-
-				break;
-			case '4': // begins with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.ip_address LIKE ' . db_qstr(get_request_var('ip_filter') . '%');
-
-				break;
-			case '5': // does not contain
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.ip_address NOT LIKE ' . db_qstr('%' . get_request_var('ip_filter') . '%');
-
-				break;
-			case '6': // does not begin with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.ip_address NOT LIKE ' . db_qstr(get_request_var('ip_filter') . '%');
-
-				break;
-			case '7': // is null
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.ip_address = ""';
-
-				break;
-			case '8': // is not null
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.ip_address != ""';
-		}
+		mactrack_typed_filter_clause('mtp.ip_address', get_request_var('ip_filter'), get_request_var('ip_filter_type_id'), $sql_where);
 	}
 
 	if ((get_request_var('port_name_filter') != '') || (get_request_var('port_name_filter_type_id') > 6)) {
-		switch (get_request_var('port_name_filter_type_id')) {
-			case '1': // do not filter
-				break;
-			case '2': // matches
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.port_name = ' . db_qstr(get_request_var('port_name_filter'));
-
-				break;
-			case '3': // contains
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.port_name LIKE ' . db_qstr('%' . get_request_var('port_name_filter') . '%');
-
-				break;
-			case '4': // begins with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.port_name LIKE ' . db_qstr(get_request_var('port_name_filter') . '%');
-
-				break;
-			case '5': // does not contain
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.port_name NOT LIKE ' . db_qstr('%' . get_request_var('port_name_filter') . '%');
-
-				break;
-			case '6': // does not begin with
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.port_name NOT LIKE ' . db_qstr(get_request_var('port_name_filter') . '%');
-
-				break;
-			case '7': // is null
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.port_name = ""';
-
-				break;
-			case '8': // is not null
-				$sql_where .= ($sql_where != '' ? ' AND' : 'WHERE') . ' mtp.port_name != ""';
-
-				break;
-		}
+		mactrack_typed_filter_clause('mtp.port_name', get_request_var('port_name_filter'), get_request_var('port_name_filter_type_id'), $sql_where);
 	}
 
 	if (get_request_var('filter') != '') {


### PR DESCRIPTION
## Summary

- Add `mactrack_typed_filter_clause()` to centralize the 8 duplicated filter-type switch blocks across view pages
- Add `mactrack_normalize_mac()` to centralize MAC delimiter stripping
- Replace all 8 switch blocks in `mactrack_view_arp.php`, `mactrack_view_macs.php`, `mactrack_view_dot1x.php`
- Net reduction: -248 lines, +57 lines

## Test plan

- [ ] Verify MAC address filtering (matches, contains, begins-with, etc.) works in ARP, MAC, and dot1x views
- [ ] Verify IP address filtering works with all filter types including is-null/is-not-null
- [ ] Verify port name filtering works in MAC and dot1x views