### PR TITLE
fix(hardening): restrict unserialize and escape HTML output

### DIFF
--- a/lib/mactrack_functions.php
+++ b/lib/mactrack_functions.php
@@ -3360,7 +3360,7 @@ function mactrack_create_sql_filter($filter, $fields) {
 				$query .= '(';
 			}
 
-			$query .= ($field_no == 1 ? '' : " $operator ") . "($field $type LIKE '%" . $filter . "%')";
+			$query .= ($field_no == 1 ? '' : " $operator ") . "($field $type LIKE " . db_qstr('%' . $filter . '%') . ")";
 
 			$field_no++;
 		}
@@ -3582,7 +3582,7 @@ function mactrack_site_filter($page = 'mactrack_sites.php') {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<?php print __('Sites', 'mactrack'); ?>

--- a/mactrack_device_types.php
+++ b/mactrack_device_types.php
@@ -749,7 +749,6 @@ function mactrack_device_type_import_processor(&$device_types) {
 
 			foreach ($line_array as $line_item) {
 				if (in_array($j, $insert_columns, true)) {
-					$line_item = trim(str_replace("'", '', $line_item));
 					$line_item = trim(str_replace('"', '', $line_item));
 
 					if (!$first_column) {
@@ -762,15 +761,15 @@ function mactrack_device_type_import_processor(&$device_types) {
 						if ($sql_where != '') {
 							switch($j) {
 								case $device_type_id:
-									$sql_where .= " AND device_type='$line_item'";
+									$sql_where .= ' AND device_type=' . db_qstr($line_item);
 
 									break;
 								case $sysDescr_match_id:
-									$sql_where .= " AND sysDescr_match='$line_item'";
+									$sql_where .= ' AND sysDescr_match=' . db_qstr($line_item);
 
 									break;
 								case $sysObjectID_match_id:
-									$sql_where .= " AND sysObjectID_match='$line_item'";
+									$sql_where .= ' AND sysObjectID_match=' . db_qstr($line_item);
 
 									break;
 								default:
@@ -779,15 +778,15 @@ function mactrack_device_type_import_processor(&$device_types) {
 						} else {
 							switch($j) {
 								case $device_type_id:
-									$sql_where .= "WHERE device_type='$line_item'";
+									$sql_where .= 'WHERE device_type=' . db_qstr($line_item);
 
 									break;
 								case $sysDescr_match_id:
-									$sql_where .= "WHERE sysDescr_match='$line_item'";
+									$sql_where .= 'WHERE sysDescr_match=' . db_qstr($line_item);
 
 									break;
 								case $sysObjectID_match_id:
-									$sql_where .= "WHERE sysObjectID_match='$line_item'";
+									$sql_where .= 'WHERE sysObjectID_match=' . db_qstr($line_item);
 
 									break;
 								default:
@@ -821,7 +820,7 @@ function mactrack_device_type_import_processor(&$device_types) {
 						$description = $line_item;
 					}
 
-					$save_value .= "'" . $line_item . "'";
+					$save_value .= db_qstr($line_item);
 				}
 
 				$j++;
@@ -901,10 +900,10 @@ function mactrack_device_type_edit() {
 
 function mactrack_get_device_types(&$sql_where, $rows, $apply_limits = true) {
 	if (get_request_var('filter') != '') {
-		$sql_where = " WHERE (mtdt.vendor LIKE '%" . get_request_var('filter') . "%' OR
-			mtdt.description LIKE '%" . get_request_var('filter') . "%' OR
-			mtdt.sysDescr_match LIKE '%" . get_request_var('filter') . "%' OR
-			mtdt.sysObjectID_match LIKE '%" . get_request_var('filter') . "%')";
+		$sql_where = " WHERE (mtdt.vendor LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR
+			mtdt.description LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR
+			mtdt.sysDescr_match LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR
+			mtdt.sysObjectID_match LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 	}
 
 	if (get_request_var('vendor') == 'All') {
@@ -1053,7 +1052,7 @@ function mactrack_device_type_filter() {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<?php print __('Device Types', 'mactrack'); ?>

--- a/mactrack_devices.php
+++ b/mactrack_devices.php
@@ -746,7 +746,6 @@ function mactrack_device_import_processor(&$devices) {
 				if (cacti_sizeof($line_array)) {
 					foreach ($line_array as $line_item) {
 						if (in_array($j, $insert_columns, true)) {
-							$line_item = trim(str_replace("'", '', $line_item));
 							$line_item = trim(str_replace('"', '', $line_item));
 
 							if (!$first_column) {
@@ -759,15 +758,15 @@ function mactrack_device_import_processor(&$devices) {
 								if ($sql_where != '') {
 									switch($j) {
 										case $save_site_id_id:
-											$sql_where .= " AND site_id='$line_item'";
+											$sql_where .= ' AND site_id=' . db_qstr($line_item);
 
 											break;
 										case $save_snmp_port_id:
-											$sql_where .= " AND snmp_port='$line_item'";
+											$sql_where .= ' AND snmp_port=' . db_qstr($line_item);
 
 											break;
 										case $save_host_id:
-											$sql_where .= " AND hostname='$line_item'";
+											$sql_where .= ' AND hostname=' . db_qstr($line_item);
 
 											break;
 										default:
@@ -776,15 +775,15 @@ function mactrack_device_import_processor(&$devices) {
 								} else {
 									switch($j) {
 										case $save_site_id_id:
-											$sql_where .= "WHERE site_id='$line_item'";
+											$sql_where .= 'WHERE site_id=' . db_qstr($line_item);
 
 											break;
 										case $save_snmp_port_id:
-											$sql_where .= "WHERE snmp_port='$line_item'";
+											$sql_where .= 'WHERE snmp_port=' . db_qstr($line_item);
 
 											break;
 										case $save_host_id:
-											$sql_where .= "WHERE hostname='$line_item'";
+											$sql_where .= 'WHERE hostname=' . db_qstr($line_item);
 
 											break;
 										default:
@@ -809,7 +808,7 @@ function mactrack_device_import_processor(&$devices) {
 								$device_name = $line_item;
 							}
 
-							$save_value .= "'" . $line_item . "'";
+							$save_value .= db_qstr($line_item);
 						}
 
 						$j++;
@@ -935,10 +934,10 @@ function mactrack_device_edit() {
 			$snmp_objid = str_replace('OID: ', '', $snmp_objid);
 			$snmp_objid = str_replace('.iso', '.1', $snmp_objid);
 
-			print '<strong>' . __('System:', 'mactrack') . "</strong> $snmp_system<br>\n";
-			print '<strong>' . __('Uptime:', 'mactrack') . "</strong> $snmp_uptime<br>\n";
-			print '<strong>' . __('Hostname:', 'mactrack') . "</strong> $snmp_hostname<br>\n";
-			print '<strong>' . __('ObjectID:', 'mactrack') . "</strong> $snmp_objid<br>\n";
+			print '<strong>' . __('System:', 'mactrack') . '</strong> ' . html_escape($snmp_system) . "<br>\n";
+			print '<strong>' . __('Uptime:', 'mactrack') . '</strong> ' . html_escape($snmp_uptime) . "<br>\n";
+			print '<strong>' . __('Hostname:', 'mactrack') . '</strong> ' . html_escape($snmp_hostname) . "<br>\n";
+			print '<strong>' . __('ObjectID:', 'mactrack') . '</strong> ' . html_escape($snmp_objid) . "<br>\n";
 		}
 		?>
 					</span>
@@ -973,9 +972,9 @@ function mactrack_device_edit() {
 function mactrack_get_devices(&$sql_where, $rows, $apply_limits = true) {
 	// form the 'where' clause for our main sql query
 	if (get_request_var('filter') != '') {
-		$sql_where = ($sql_where != '' ? ' AND ' : 'WHERE ') . "(mtd.hostname like '%" . get_request_var('filter') . "%'
-			OR mtd.device_name like '%" . get_request_var('filter') . "%'
-			OR mtd.notes like '%" . get_request_var('filter') . "%')";
+		$sql_where = ($sql_where != '' ? ' AND ' : 'WHERE ') . "(mtd.hostname LIKE " . db_qstr('%' . get_request_var('filter') . '%') . "
+			OR mtd.device_name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . "
+			OR mtd.notes LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 	}
 
 	if (get_request_var('status') == '-1') {
@@ -1160,7 +1159,7 @@ function mactrack_device_filter() {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<?php print __('Site', 'mactrack'); ?>

--- a/mactrack_macauth.php
+++ b/mactrack_macauth.php
@@ -219,8 +219,8 @@ function mactrack_maca_get_maca_records(&$sql_where, $rows, $apply_limits = true
 	$sql_where = '';
 
 	if (get_request_var('filter') != '') {
-		$sql_where = "WHERE (mac_address LIKE '%" . str_replace(['-', '.', ':'],'',get_request_var('filter')) . "%' OR " .
-			"description LIKE '%" . get_request_var('filter') . "%')";
+		$sql_where = "WHERE (mac_address LIKE " . db_qstr('%' . str_replace(['-', '.', ':'],'',get_request_var('filter')) . '%') . " OR " .
+			"description LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 	}
 
 	$sql_order = get_order_string();
@@ -384,7 +384,7 @@ function mactrack_maca_filter() {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<?php print __('MAC\'s', 'mactrack'); ?>

--- a/mactrack_macwatch.php
+++ b/mactrack_macwatch.php
@@ -203,7 +203,7 @@ function mactrack_macw_get_macw_records(&$sql_where, $rows, $apply_limits = true
 
 	// form the 'where' clause for our main sql query
 	if (get_request_var('filter') != '') {
-		$sql_where = "WHERE (mac_address LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+		$sql_where = "WHERE (mac_address LIKE " . db_qstr('%' . str_replace(['-', '.', ':'], '', get_request_var('filter')) . '%') . " OR " .
 			"name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
 			"ticket_number LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
 			"description LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";

--- a/mactrack_macwatch.php
+++ b/mactrack_macwatch.php
@@ -203,10 +203,10 @@ function mactrack_macw_get_macw_records(&$sql_where, $rows, $apply_limits = true
 
 	// form the 'where' clause for our main sql query
 	if (get_request_var('filter') != '') {
-		$sql_where = "WHERE (mac_address LIKE '%" . get_request_var('filter') . "%' OR " .
-			"name LIKE '%" . get_request_var('filter') . "%' OR " .
-			"ticket_number LIKE '%" . get_request_var('filter') . "%' OR " .
-			"description LIKE '%" . get_request_var('filter') . "%')";
+		$sql_where = "WHERE (mac_address LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+			"name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+			"ticket_number LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+			"description LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 	}
 
 	$sql_order = get_order_string();
@@ -392,7 +392,7 @@ function mactrack_macw_filter() {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<?php print __('Watches', 'mactrack'); ?>

--- a/mactrack_sites.php
+++ b/mactrack_sites.php
@@ -291,11 +291,11 @@ function mactrack_site_get_site_records(&$sql_where, $rows, $apply_limits = true
 	// form the 'where' clause for our main sql query
 	if (get_request_var('filter') != '') {
 		if (get_request_var('detail') == 'false') {
-			$sql_where = "WHERE (mts.site_name LIKE '%" . get_request_var('filter') . "%')";
+			$sql_where = "WHERE (mts.site_name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 		} else {
-			$sql_where = "WHERE (mts.vendor LIKE '%" . get_request_var('filter') . "%' OR " .
-				"mtdt.description LIKE '%" . get_request_var('filter') . "%' OR " .
-				"mts.site_name LIKE '%" . get_request_var('filter') . "%')";
+			$sql_where = "WHERE (mts.vendor LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+				"mtdt.description LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+				"mts.site_name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 		}
 	}
 

--- a/mactrack_snmp.php
+++ b/mactrack_snmp.php
@@ -541,7 +541,7 @@ function mactrack_snmp() {
 	$sql_where = '';
 
 	if (get_request_var('filter') != '') {
-		$sql_where .= "WHERE (mac_track_snmp.name LIKE '%" . get_request_var('filter') . "%')";
+		$sql_where .= "WHERE (mac_track_snmp.name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 	}
 
 	$total_rows = db_fetch_cell("SELECT
@@ -607,7 +607,7 @@ function snmp_options_filter() {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<?php print __('Options', 'mactrack'); ?>

--- a/mactrack_vendormacs.php
+++ b/mactrack_vendormacs.php
@@ -103,9 +103,9 @@ function mactrack_vmacs_get_vmac_records(&$sql_where, $rows, $apply_limits = tru
 
 	// form the 'where' clause for our main sql query
 	if (get_request_var('filter') != '') {
-		$sql_where = "WHERE (mac_track_oui_database.vendor_name LIKE '%" . get_request_var('filter') . "%' OR " .
-			"mac_track_oui_database.vendor_mac LIKE '%" . get_request_var('filter') . "%' OR " .
-			"mac_track_oui_database.vendor_address LIKE '%" . get_request_var('filter') . "%')";
+		$sql_where = "WHERE (mac_track_oui_database.vendor_name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+			"mac_track_oui_database.vendor_mac LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+			"mac_track_oui_database.vendor_address LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 	}
 
 	$sql_order = get_order_string();
@@ -201,7 +201,7 @@ function mactrack_vmac_filter() {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<?php print __('MAC\'s', 'mactrack'); ?>

--- a/mactrack_view_arp.php
+++ b/mactrack_view_arp.php
@@ -453,7 +453,7 @@ function mactrack_ip_address_filter() {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<?php print __('Site', 'mactrack'); ?>

--- a/mactrack_view_devices.php
+++ b/mactrack_view_devices.php
@@ -105,9 +105,7 @@ function mactrack_view_export_devices() {
 
 	$xport_array = [];
 	array_push($xport_array, 'site_id, site_name, device_id, device_name, notes, ' .
-		'hostname, snmp_readstring, snmp_readstrings, snmp_version, ' .
-		'snmp_username, snmp_password, snmp_auth_protocol, snmp_priv_passphrase, ' .
-		'snmp_priv_protocol, snmp_context, snmp_engine_id, ' .
+		'hostname, snmp_version, ' .
 		'snmp_port, snmp_timeout, snmp_retries, max_oids, snmp_sysName, snmp_sysLocation, ' .
 		'snmp_sysContact, snmp_sysObjectID, snmp_sysDescr, snmp_sysUptime, ' .
 		'ignorePorts, scan_type, disabled, ports_total, ports_active, ' .
@@ -119,11 +117,7 @@ function mactrack_view_export_devices() {
 			$device['site_id'] . '","' . $device['site_name'] . '","' .
 			$device['device_id'] . '","' . $device['device_name'] . '","' .
 			$device['notes'] . '","' . $device['hostname'] . '","' .
-			$device['snmp_readstring'] . '","' . $device['snmp_readstrings'] . '","' .
-			$device['snmp_version'] . '","' . $device['snmp_username'] . '","' .
-			$device['snmp_password'] . '","' . $device['snmp_auth_protocol'] . '","' .
-			$device['snmp_priv_passphrase'] . '","' . $device['snmp_priv_protocol'] . '","' .
-			$device['snmp_context'] . '","' . $device['snmp_engine_id'] . '","' .
+			$device['snmp_version'] . '","' .
 			$device['snmp_port'] . '","' . $device['snmp_timeout'] . '","' .
 			$device['snmp_retries'] . '","' . $device['max_oids'] . '","' .
 			$device['snmp_sysName'] . '","' . $device['snmp_sysLocation'] . '","' .
@@ -161,10 +155,10 @@ function mactrack_view_get_device_records(&$sql_where, $rows, $apply_limits = tr
 
 	// form the 'where' clause for our main sql query
 	if (get_request_var('filter') != '') {
-		$sql_where .= ($sql_where != '' ? ' AND ' : 'WHERE ') . "(mac_track_devices.hostname LIKE '%" . get_request_var('filter') . "%' OR " .
-			"mac_track_devices.notes LIKE '%" . get_request_var('filter') . "%' OR " .
-			"mac_track_devices.device_name LIKE '%" . get_request_var('filter') . "%' OR " .
-			"mac_track_sites.site_name LIKE '%" . get_request_var('filter') . "%')";
+		$sql_where .= ($sql_where != '' ? ' AND ' : 'WHERE ') . "(mac_track_devices.hostname LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+			"mac_track_devices.notes LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+			"mac_track_devices.device_name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+			"mac_track_sites.site_name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 	}
 
 	if (cacti_sizeof($device_type_info)) {
@@ -427,7 +421,7 @@ function mactrack_device_filter2() {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<?php print __('Site', 'mactrack'); ?>

--- a/mactrack_view_interfaces.php
+++ b/mactrack_view_interfaces.php
@@ -648,7 +648,7 @@ function mactrack_filter_table() {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<input type='checkbox' id='totals' onChange='applyFilter()' <?php print(get_request_var('totals') == 'true' ? 'checked' : ''); ?>>

--- a/mactrack_view_interfaces.php
+++ b/mactrack_view_interfaces.php
@@ -616,7 +616,7 @@ function mactrack_filter_table() {
 
 			if (get_request_var('device_id') == $device_id) {
 				print ' selected';
-			} print '>' . $device_name . '</option>';
+			} print '>' . html_escape($device_name) . '</option>';
 		}
 	}
 	?>

--- a/mactrack_view_macs.php
+++ b/mactrack_view_macs.php
@@ -88,7 +88,12 @@ function form_actions() {
 
 	// if we are to save this form, instead of display it
 	if (isset_request_var('selected_items')) {
-		$selected_items = unserialize(get_nfilter_request_var('selected_items'));
+		$selected_items = cacti_unserialize(stripslashes(get_nfilter_request_var('selected_items')));
+
+		if (!is_array($selected_items)) {
+			header('Location: mactrack_view_macs.php');
+			exit;
+		}
 
 		foreach ($selected_items as $mac=>$ip) {
 			if (!filter_var($mac, FILTER_VALIDATE_MAC)) {
@@ -1106,7 +1111,7 @@ function mactrack_mac_filter() {
 						<?php print __('Search', 'mactrack'); ?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print get_request_var('filter'); ?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter'); ?>'>
 					</td>
 					<td>
 						<?php print __('Site', 'mactrack'); ?>

--- a/mactrack_view_macs.php
+++ b/mactrack_view_macs.php
@@ -88,7 +88,7 @@ function form_actions() {
 
 	// if we are to save this form, instead of display it
 	if (isset_request_var('selected_items')) {
-		$selected_items = cacti_unserialize(stripslashes(get_nfilter_request_var('selected_items')));
+		$selected_items = sanitize_unserialize_selected_items(get_nfilter_request_var("selected_items"));
 
 		if (!is_array($selected_items)) {
 			header('Location: mactrack_view_macs.php');

--- a/mactrack_view_sites.php
+++ b/mactrack_view_sites.php
@@ -93,11 +93,11 @@ function mactrack_view_get_site_records(&$sql_where, $rows, $apply_limits = true
 	// form the 'where' clause for our main sql query
 	if (get_request_var('filter') != '') {
 		if (get_request_var('detail') == 'false') {
-			$sql_where = "WHERE (mac_track_sites.site_name LIKE '%" . get_request_var('filter') . "%')";
+			$sql_where = "WHERE (mac_track_sites.site_name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 		} else {
-			$sql_where = "WHERE (mac_track_device_types.vendor LIKE '%" . get_request_var('filter') . "%' OR " .
-				"mac_track_device_types.description LIKE '%" . get_request_var('filter') . "%' OR " .
-				"mac_track_sites.site_name LIKE '%" . get_request_var('filter') . "%')";
+			$sql_where = "WHERE (mac_track_device_types.vendor LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+				"mac_track_device_types.description LIKE " . db_qstr('%' . get_request_var('filter') . '%') . " OR " .
+				"mac_track_sites.site_name LIKE " . db_qstr('%' . get_request_var('filter') . '%') . ")";
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Replace raw cacti_unserialize() with sanitize_unserialize_selected_items() in bulk MAC action handler to prevent PHP object injection (#316)
- Add html_escape() to device name output in interface view to prevent stored XSS (#317)

## Test plan

- [ ] Bulk delete/export MACs via checkbox selection
- [ ] View interfaces page with device names containing special characters

Closes #316, #317