### PR TITLE
fix(mactrack_strip_alpha): correct alphabet list 'uvwzyz' -> 'uvwxyz'

### DIFF
--- a/lib/mactrack_functions.php
+++ b/lib/mactrack_functions.php
@@ -126,7 +126,7 @@ function mactrack_rebuild_scanning_funcs() {
 }
 
 function mactrack_strip_alpha($string = '') {
-	return trim($string, 'abcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZ()[]{}');
+	return trim($string, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ()[]{}');
 }
 
 function mactrack_check_user_realm($realm_id) {


### PR DESCRIPTION
Fixes #283.

Real bug, not cosmetic: the trim-character list in `mactrack_strip_alpha()` used `...uvwzyz...` (duplicate y+z, missing x) so **`x`/`X` were never stripped** from port / interface strings. Affects the tplink, norbay, foundry, enterasys drivers that call this helper.

```diff
- return trim($string, 'abcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWXYZ()[]{}');
+ return trim($string, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ()[]{}');
```

Uppercase half was already correct. Single-line fix.