### PR TITLE
Fix runtime dependency handling and verify production scanner path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.phpunit.result.cache
+vendor

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -25,6 +25,16 @@ permissions:
   contents: read
 
 jobs:
+  runtime-coverage:
+    name: Docker tests and runtime coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout plugin
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run tests and enforce 100% runtime coverage in PHP 8.3
+        run: tests/docker/run-tests.sh
+
   lint:
     name: PHP Lint (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -32,6 +32,28 @@ on:
       - develop
 
 jobs:
+  production-path:
+    name: Production scanner path
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Cacti develop
+      uses: actions/checkout@v7
+      with:
+        repository: Cacti/cacti
+        ref: develop
+        path: cacti
+
+    - name: Checkout mactrack plugin
+      uses: actions/checkout@v7
+      with:
+        path: cacti/plugins/mactrack
+
+    - name: Run installed Cacti, MariaDB, SNMP, scanner, and poller
+      env:
+        CACTI_SOURCE: ${{ github.workspace }}/cacti
+        MACTRACK_SOURCE: ${{ github.workspace }}/cacti/plugins/mactrack
+      run: cacti/plugins/mactrack/tests/e2e/run-mactrack-e2e.sh
+
   integration-test:
     runs-on: ${{ matrix.os }}
     
@@ -107,16 +129,14 @@ jobs:
         cat ~/.my.cnf
     
     - name: Initialize Cacti Database
-      env:
-        MYSQL_AUTH_USR: '--defaults-file=~/.my.cnf'
       run: |
-        mysql $MYSQL_AUTH_USR -e 'CREATE DATABASE IF NOT EXISTS cacti;'
-        mysql $MYSQL_AUTH_USR -e "CREATE USER IF NOT EXISTS 'cactiuser'@'localhost' IDENTIFIED BY 'cactiuser';"
-        mysql $MYSQL_AUTH_USR -e "GRANT ALL PRIVILEGES ON cacti.* TO 'cactiuser'@'localhost';"
-        mysql $MYSQL_AUTH_USR -e "GRANT SELECT ON mysql.time_zone_name TO 'cactiuser'@'localhost';"
-        mysql $MYSQL_AUTH_USR -e "FLUSH PRIVILEGES;"
-        mysql $MYSQL_AUTH_USR cacti < ${{ github.workspace }}/cacti/cacti.sql
-        mysql $MYSQL_AUTH_USR -e "INSERT INTO settings (name, value) VALUES ('path_php_binary', '/usr/bin/php')" cacti
+        mysql --defaults-file="$HOME/.my.cnf" -e 'CREATE DATABASE IF NOT EXISTS cacti;'
+        mysql --defaults-file="$HOME/.my.cnf" -e "CREATE USER IF NOT EXISTS 'cactiuser'@'localhost' IDENTIFIED BY 'cactiuser';"
+        mysql --defaults-file="$HOME/.my.cnf" -e "GRANT ALL PRIVILEGES ON cacti.* TO 'cactiuser'@'localhost';"
+        mysql --defaults-file="$HOME/.my.cnf" -e "GRANT SELECT ON mysql.time_zone_name TO 'cactiuser'@'localhost';"
+        mysql --defaults-file="$HOME/.my.cnf" -e "FLUSH PRIVILEGES;"
+        mysql --defaults-file="$HOME/.my.cnf" cacti < "${{ github.workspace }}/cacti/cacti.sql"
+        mysql --defaults-file="$HOME/.my.cnf" -e "INSERT INTO settings (name, value) VALUES ('path_php_binary', '/usr/bin/php')" cacti
     
     - name: Validate composer files
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 --- develop ---
 
+* issue#343: Fail closed when Composer dependencies are missing and test the production scanner path against live SNMP
 * compat: Replace vendored Net_DNS2 with Composer-managed mikepultz/netdns2 1.5, retaining the established resolver API
 * issue: Harden device-type vendor filtering against SQL injection
 * issue: Validate aggregated MAC bulk-action IDs and use prepared deletion SQL

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,11 @@
     "description": "Cacti Mactrack plugin test tooling",
     "type": "cacti-plugin",
     "license": "GPL-2.0-or-later",
+    "autoload": {
+        "psr-4": {
+            "Cacti\\Mactrack\\": "src/"
+        }
+    },
     "require-dev": {
         "pestphp/pest": "^1.23",
         "phpunit/phpunit": "^9.6",
@@ -14,6 +19,7 @@
         "test:integration": "pest tests/Pest/Integration",
         "test:e2e:static": "pest tests/Pest/E2E",
         "test:coverage": "pest --coverage",
+        "test:coverage:runtime": "pest --configuration=phpunit.runtime.xml --coverage --min=100",
         "analyse": "psalm --no-progress"
     },
     "config": {

--- a/mactrack_resolver.php
+++ b/mactrack_resolver.php
@@ -42,10 +42,17 @@ chdir($dir);
 
 include('../../include/cli_check.php');
 include_once($config['base_path'] . '/plugins/mactrack/lib/mactrack_functions.php');
-require_once $config['base_path'] . '/plugins/mactrack/vendor/autoload.php';
+require_once $config['base_path'] . '/plugins/mactrack/src/Runtime/DependencyBootstrap.php';
 
-if (!class_exists('Net_DNS2_Resolver')) {
-	fwrite(STDERR, "Mactrack DNS dependency is unavailable. Run composer install --no-dev in the plugin directory.\n");
+$dependenciesLoaded = \Cacti\Mactrack\Runtime\DependencyBootstrap::load(
+	$config['base_path'] . '/plugins/mactrack/vendor/autoload.php',
+	['Net_DNS2_Resolver'],
+	static function (string $message): void {
+		fwrite(STDERR, $message . "\n");
+	}
+);
+
+if (!$dependenciesLoaded) {
 	exit(1);
 }
 

--- a/phpunit.runtime.xml
+++ b/phpunit.runtime.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/Pest.php" colors="true">
+    <testsuites>
+        <testsuite name="Runtime dependency contract">
+            <directory suffix="Test.php">tests/Pest/Unit/Runtime</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src/Runtime</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/setup.php
+++ b/setup.php
@@ -62,18 +62,17 @@ function plugin_mactrack_version() {
 function plugin_mactrack_check_config() {
 	global $config;
 
-	$autoload = $config['base_path'] . '/plugins/mactrack/vendor/autoload.php';
+	require_once $config['base_path'] . '/plugins/mactrack/src/Runtime/DependencyBootstrap.php';
 
-	if (!is_file($autoload)) {
-		cacti_log('ERROR: Mactrack requires Composer dependencies. Run composer install --no-dev in plugins/mactrack before enabling the plugin.', false, 'MACTRACK');
+	$loaded = \Cacti\Mactrack\Runtime\DependencyBootstrap::load(
+		$config['base_path'] . '/plugins/mactrack/vendor/autoload.php',
+		['Net_DNS2_Resolver'],
+		static function (string $message): void {
+			cacti_log('ERROR: ' . $message, false, 'MACTRACK');
+		}
+	);
 
-		return false;
-	}
-
-	require_once $autoload;
-
-	if (!class_exists('Net_DNS2_Resolver')) {
-		cacti_log('ERROR: Mactrack DNS dependency is unavailable. Run composer install --no-dev in plugins/mactrack before enabling the plugin.', false, 'MACTRACK');
+	if (!$loaded) {
 
 		return false;
 	}

--- a/src/Runtime/DependencyBootstrap.php
+++ b/src/Runtime/DependencyBootstrap.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cacti\Mactrack\Runtime;
+
+use Throwable;
+
+final class DependencyBootstrap {
+	/**
+	 * @param list<class-string>       $requiredClasses
+	 * @param null|callable(string):void $reporter
+	 */
+	public static function load(
+		string $autoloadPath,
+		array $requiredClasses = ['Net_DNS2_Resolver'],
+		?callable $reporter = null
+	): bool {
+		$reporter ??= static function (string $_message): void {
+		};
+
+		if (!is_file($autoloadPath)) {
+			$reporter('Mactrack requires Composer dependencies. Run composer install --no-dev in the plugin directory.');
+
+			return false;
+		}
+
+		try {
+			require_once $autoloadPath;
+		} catch (Throwable $error) {
+			$reporter('Mactrack could not load Composer dependencies: ' . $error->getMessage());
+
+			return false;
+		}
+
+		foreach ($requiredClasses as $requiredClass) {
+			if (!class_exists($requiredClass)) {
+				$reporter('Mactrack Composer dependency is unavailable: ' . $requiredClass . '. Run composer install --no-dev in the plugin directory.');
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/tests/Pest/Unit/Runtime/DependencyBootstrapTest.php
+++ b/tests/Pest/Unit/Runtime/DependencyBootstrapTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Cacti\Mactrack\Runtime\DependencyBootstrap;
+
+beforeAll(function (): void {
+	require_once __DIR__ . '/../../../../src/Runtime/DependencyBootstrap.php';
+});
+
+it('reports a missing Composer autoloader', function (): void {
+	$messages = [];
+
+	$loaded = DependencyBootstrap::load(
+		__DIR__ . '/fixtures/does-not-exist.php',
+		['MactrackMissingDependency'],
+		static function (string $message) use (&$messages): void {
+			$messages[] = $message;
+		}
+	);
+
+	expect($loaded)->toBeFalse()
+		->and($messages)->toBe([
+			'Mactrack requires Composer dependencies. Run composer install --no-dev in the plugin directory.',
+		]);
+});
+
+it('fails quietly when no reporter is supplied', function (): void {
+	expect(DependencyBootstrap::load(
+		__DIR__ . '/fixtures/does-not-exist.php',
+		['MactrackMissingDependency']
+	))->toBeFalse();
+});
+
+it('reports an autoloader failure', function (): void {
+	$messages = [];
+
+	$loaded = DependencyBootstrap::load(
+		__DIR__ . '/fixtures/throwing-autoload.php',
+		['MactrackThrowingDependency'],
+		static function (string $message) use (&$messages): void {
+			$messages[] = $message;
+		}
+	);
+
+	expect($loaded)->toBeFalse()
+		->and($messages)->toBe(['Mactrack could not load Composer dependencies: fixture failure']);
+});
+
+it('reports an unavailable required class', function (): void {
+	$messages = [];
+
+	$loaded = DependencyBootstrap::load(
+		__DIR__ . '/fixtures/empty-autoload.php',
+		['MactrackUnavailableDependency'],
+		static function (string $message) use (&$messages): void {
+			$messages[] = $message;
+		}
+	);
+
+	expect($loaded)->toBeFalse()
+		->and($messages)->toBe([
+			'Mactrack Composer dependency is unavailable: MactrackUnavailableDependency. Run composer install --no-dev in the plugin directory.',
+		]);
+});
+
+it('loads every required dependency', function (): void {
+	$loaded = DependencyBootstrap::load(
+		__DIR__ . '/fixtures/working-autoload.php',
+		['MactrackFixtureDependency']
+	);
+
+	expect($loaded)->toBeTrue()
+		->and(class_exists('MactrackFixtureDependency'))->toBeTrue();
+});

--- a/tests/Pest/Unit/Runtime/fixtures/empty-autoload.php
+++ b/tests/Pest/Unit/Runtime/fixtures/empty-autoload.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/Pest/Unit/Runtime/fixtures/throwing-autoload.php
+++ b/tests/Pest/Unit/Runtime/fixtures/throwing-autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+throw new RuntimeException('fixture failure');

--- a/tests/Pest/Unit/Runtime/fixtures/working-autoload.php
+++ b/tests/Pest/Unit/Runtime/fixtures/working-autoload.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+final class MactrackFixtureDependency {
+}

--- a/tests/Unit/test_device_type_sql_safety.php
+++ b/tests/Unit/test_device_type_sql_safety.php
@@ -127,20 +127,19 @@ if ($convertSource                                                              
 
 $resolverSource = file_get_contents(__DIR__ . '/../../mactrack_resolver.php');
 
-if ($resolverSource                                                                                         === false ||
-	strpos($resolverSource, 'require_once $config[\'base_path\'] . \'/plugins/mactrack/vendor/autoload.php\'') === false ||
-	strpos($resolverSource, "class_exists('Net_DNS2_Resolver')")                                               === false) {
+if ($resolverSource === false ||
+	strpos($resolverSource, '\\Cacti\\Mactrack\\Runtime\\DependencyBootstrap::load(') === false ||
+	strpos($resolverSource, 'if (!$dependenciesLoaded)') === false) {
 	fwrite(STDERR, "DNS resolver must load and verify the Composer-managed NetDNS2 dependency\n");
 	exit(1);
 }
 
 $setupSource = file_get_contents(__DIR__ . '/../../setup.php');
 
-if ($setupSource                                               === false ||
+if ($setupSource === false ||
 	strpos($setupSource, '/plugins/mactrack/vendor/autoload.php') === false ||
-	strpos($setupSource, 'require_once $autoload;')               === false ||
-	strpos($setupSource, "class_exists('Net_DNS2_Resolver')")     === false ||
-	strpos($setupSource, 'return false;')                         === false) {
+	strpos($setupSource, '\\Cacti\\Mactrack\\Runtime\\DependencyBootstrap::load(') === false ||
+	strpos($setupSource, 'if (!$loaded)') === false) {
 	fwrite(STDERR, "Mactrack configuration checks must block enablement without a usable Composer dependency\n");
 	exit(1);
 }

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM composer:2 AS composer
+
+FROM php:8.3-cli
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends $PHPIZE_DEPS git unzip \
+    && pecl install pcov \
+    && docker-php-ext-enable pcov \
+    && rm -rf /var/lib/apt/lists/* /tmp/pear
+
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+
+WORKDIR /app
+
+COPY composer.json composer.lock ./
+RUN composer install --no-interaction --no-progress --prefer-dist
+
+COPY . .
+
+CMD ["sh", "-ec", "php vendor/bin/pest && php vendor/bin/pest --configuration=phpunit.runtime.xml --coverage --min=100 && composer validate --strict"]

--- a/tests/docker/run-tests.sh
+++ b/tests/docker/run-tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+IMAGE="mactrack-tests:php83"
+
+docker build --file "$SOURCE_DIR/tests/docker/Dockerfile" --tag "$IMAGE" "$SOURCE_DIR"
+docker run --rm "$IMAGE"

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -5,7 +5,7 @@ FROM php:8.3-apache
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends default-mysql-client fping libfreetype6-dev libgmp-dev libicu-dev libjpeg-dev libldap2-dev libonig-dev libpng-dev libsnmp-dev libxml2-dev rrdtool snmp snmpd \
+    && apt-get install -y --no-install-recommends default-mysql-client fping libfreetype6-dev libgmp-dev libicu-dev libjpeg-dev libldap2-dev libonig-dev libpng-dev libsnmp-dev libxml2-dev rrdtool snmp snmpd unzip \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j"$(nproc)" gd gmp intl ldap mbstring mysqli pcntl pdo_mysql snmp sockets xml \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -1,12 +1,16 @@
-FROM php:8.2-apache
+FROM composer:2 AS composer
+
+FROM php:8.3-apache
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends default-mysql-client libfreetype6-dev libgmp-dev libicu-dev libjpeg-dev libldap2-dev libonig-dev libpng-dev libsnmp-dev libxml2-dev rrdtool snmp snmpd \
+    && apt-get install -y --no-install-recommends default-mysql-client fping libfreetype6-dev libgmp-dev libicu-dev libjpeg-dev libldap2-dev libonig-dev libpng-dev libsnmp-dev libxml2-dev rrdtool snmp snmpd \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j"$(nproc)" gd gmp intl ldap mbstring mysqli pcntl pdo_mysql snmp sockets xml \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini \
     && { echo 'date.timezone = UTC'; echo 'memory_limit = 512M'; echo 'max_execution_time = 60'; } > /usr/local/etc/php/conf.d/mactrack-e2e.ini
+
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer

--- a/tests/e2e/bootstrap-mactrack.sh
+++ b/tests/e2e/bootstrap-mactrack.sh
@@ -18,6 +18,12 @@ sed -i \
 	"$CACTI_PATH/include/config.php"
 
 composer install \
+	--working-dir="$CACTI_PATH" \
+	--no-dev \
+	--prefer-dist \
+	--no-progress \
+	--no-interaction
+composer install \
 	--working-dir="$CACTI_PATH/plugins/mactrack" \
 	--no-dev \
 	--prefer-dist \

--- a/tests/e2e/bootstrap-mactrack.sh
+++ b/tests/e2e/bootstrap-mactrack.sh
@@ -17,16 +17,51 @@ sed -i \
 	-e "s/\$database_password *=.*/\$database_password = 'mactrack-test';/" \
 	"$CACTI_PATH/include/config.php"
 
+composer install \
+	--working-dir="$CACTI_PATH/plugins/mactrack" \
+	--no-dev \
+	--prefer-dist \
+	--no-progress \
+	--no-interaction
 test -f "$CACTI_PATH/plugins/mactrack/vendor/autoload.php"
 
-# The plugin lifecycle does not need Cacti's optional device-template imports.
-# Explicitly skip them to keep this disposable install focused and fast enough
-# for CI while preserving the normal core install and plugin-management paths.
-template_args=()
-for template in "$CACTI_PATH"/install/templates/*.xml.gz; do
-	template_args+=("--template=$(basename "$template"):0")
-done
-
-php "$CACTI_PATH/cli/install_cacti.php" --accept-eula --install --force "${template_args[@]}"
+php "$CACTI_PATH/cli/install_cacti.php" --accept-eula --install --force
 php "$CACTI_PATH/cli/plugin_manage.php" --plugin=mactrack --install --enable --allperms
 php "$CACTI_PATH/plugins/mactrack/tests/e2e/mactrack_smoke.php"
+
+# Prove the installed plugin can reach a real SNMP agent through the same
+# scanner entry point launched by the Mactrack poller in production.
+snmpget -v2c -c public -On snmp-agent .1.3.6.1.2.1.1.2.0
+device_id="$(php "$CACTI_PATH/plugins/mactrack/tests/e2e/mactrack_production_probe.php" seed)"
+php "$CACTI_PATH/plugins/mactrack/mactrack_scanner.php" "-id=$device_id" --debug -t
+php "$CACTI_PATH/plugins/mactrack/tests/e2e/mactrack_production_probe.php" assert "$device_id"
+
+# The master poller must launch the scanner successfully too; this checks the
+# actual scheduler-to-worker boundary rather than a test-only function call.
+php "$CACTI_PATH/plugins/mactrack/poller_mactrack.php" -sid=1 --force --debug
+php "$CACTI_PATH/plugins/mactrack/tests/e2e/mactrack_production_probe.php" assert "$device_id"
+
+# Exercise the resolver entry point from an installed-tree copy without
+# Composer output. It must fail closed with an actionable error, never fatal.
+missing_tree=/tmp/cacti-mactrack-missing-dependencies
+cp -a "$CACTI_PATH" "$missing_tree"
+rm -rf "$missing_tree/plugins/mactrack/vendor"
+set +e
+resolver_output="$(cd "$missing_tree/plugins/mactrack" && php mactrack_resolver.php 2>&1)"
+resolver_status=$?
+set -e
+
+if [ "$resolver_status" -ne 1 ]; then
+	printf 'Resolver returned %s instead of 1 without Composer dependencies\n%s\n' "$resolver_status" "$resolver_output" >&2
+	exit 1
+fi
+
+if ! grep -q 'requires Composer dependencies' <<<"$resolver_output"; then
+	printf 'Resolver did not emit the dependency remediation message\n%s\n' "$resolver_output" >&2
+	exit 1
+fi
+
+if grep -q 'Fatal error' <<<"$resolver_output"; then
+	printf 'Resolver fatally crashed without Composer dependencies\n%s\n' "$resolver_output" >&2
+	exit 1
+fi

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -40,6 +40,21 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      snmp-agent:
+        condition: service_healthy
+
+  snmp-agent:
+    build:
+      context: ${CACTI_SOURCE:?Set CACTI_SOURCE to a Cacti checkout}
+      dockerfile: ${MACTRACK_SOURCE:?Set MACTRACK_SOURCE to this plugin checkout}/tests/e2e/Dockerfile
+    command: ["snmpd", "-f", "-Lo", "-C", "-c", "/etc/snmp/mactrack-snmpd.conf"]
+    volumes:
+      - ./snmpd.conf:/etc/snmp/mactrack-snmpd.conf:ro
+    healthcheck:
+      test: ["CMD", "snmpget", "-v2c", "-c", "public", "-On", "localhost", ".1.3.6.1.2.1.1.2.0"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
 
 volumes:
   mactrack_cache:

--- a/tests/e2e/mactrack_production_probe.php
+++ b/tests/e2e/mactrack_production_probe.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../../../include/cli_check.php';
+
+$action = $argv[1] ?? '';
+
+if ($action === 'seed') {
+	set_config_option('mt_collection_timing', '5');
+	set_config_option('mt_processes', '1');
+	set_config_option('mt_reverse_dns', '');
+
+	$siteId = (int) db_fetch_cell("SELECT site_id FROM mac_track_sites WHERE site_name = 'Default'");
+
+	db_execute_prepared('DELETE FROM mac_track_devices WHERE hostname = ?', ['snmp-agent']);
+	db_execute_prepared('DELETE FROM mac_track_device_types WHERE description = ?', ['Mactrack production-path Linux']);
+	db_execute_prepared(
+		'INSERT INTO mac_track_device_types
+			(description, vendor, device_type, sysDescr_match, sysObjectID_match,
+			scanning_function, ip_scanning_function, dot1x_scanning_function,
+			serial_number_oid, lowPort, highPort, disabled)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+		[
+			'Mactrack production-path Linux', 'Net-SNMP', '1', '*Linux*', '',
+			'get_linux_switch_ports', '', '', '', 0, 0, '',
+		]
+	);
+
+	db_execute_prepared(
+		'INSERT INTO mac_track_devices
+			(site_id, device_name, hostname, disabled, scan_type, snmp_readstring,
+			snmp_version, snmp_port, snmp_timeout, snmp_retries, max_oids)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+		[$siteId, 'Production path SNMP agent', 'snmp-agent', '', 1, 'public', '2', 161, 1000, 1, 10]
+	);
+
+	print db_fetch_insert_id();
+	exit(0);
+}
+
+if ($action === 'assert') {
+	$deviceId = filter_var($argv[2] ?? null, FILTER_VALIDATE_INT);
+
+	if ($deviceId === false) {
+		fwrite(STDERR, "Production probe requires a numeric device id\n");
+		exit(2);
+	}
+
+	$device = db_fetch_row_prepared(
+		'SELECT snmp_status, snmp_sysDescr, device_type_id, last_rundate, last_runmessage
+		FROM mac_track_devices WHERE device_id = ?',
+		[$deviceId]
+	);
+
+	$passed = (int) ($device['snmp_status'] ?? 0) === HOST_UP
+		&& str_contains((string) ($device['snmp_sysDescr'] ?? ''), 'Linux')
+		&& (int) ($device['device_type_id'] ?? 0) > 0
+		&& ($device['last_rundate'] ?? '0000-00-00 00:00:00') !== '0000-00-00 00:00:00';
+
+	if (!$passed) {
+		fwrite(STDERR, 'Production scanner assertion failed: ' . json_encode($device, JSON_THROW_ON_ERROR) . "\n");
+		exit(1);
+	}
+
+	print "Mactrack production scanner passed against the SNMP agent\n";
+	exit(0);
+}
+
+fwrite(STDERR, "Usage: mactrack_production_probe.php seed|assert [device-id]\n");
+exit(2);

--- a/tests/e2e/snmpd.conf
+++ b/tests/e2e/snmpd.conf
@@ -1,0 +1,7 @@
+agentaddress udp:161
+view all included .1
+rocommunity public default -V all
+sysLocation Mactrack production-path fixture
+sysContact Cacti CI
+sysName mactrack-snmp-agent
+dontLogTCPWrappersConnects yes


### PR DESCRIPTION
Fixes #343

## What this does

- centralizes Composer runtime bootstrapping and fails closed with actionable errors
- uses PSR-4 for new MacTrack runtime code
- validates plugin enablement and the resolver entry point when dependencies are absent
- adds a PHP 8.3 Docker gate for the full Pest suite and 100% line coverage of all new runtime code
- adds a production-path Docker test using current Cacti `develop`, MariaDB, and a live Net-SNMP agent
- runs both the real `mactrack_scanner.php` entry point and the real `poller_mactrack.php` scheduler-to-worker path, then verifies persisted scan state
- installs locked Cacti and MacTrack production dependencies inside Docker from a clean checkout

## Validation

- `tests/docker/run-tests.sh`: 14 tests passed; new runtime code 100.00% covered; Composer validation passed
- clean `tests/e2e/run-mactrack-e2e.sh`: both lock files installed inside Docker, then Cacti installation, plugin installation, live SNMP scan, poller subprocess scan, database assertions, and missing-dependency failure path passed on PHP 8.3
- `actionlint`: passed
- `git diff --check`: passed

## CI follow-up

The clean GitHub runner exposed two assumptions hidden by an existing local worktree: no archive extractor in the image, and incomplete committed Cacti autoload artifacts. The image now includes `unzip`, and the bootstrap installs both Cacti and MacTrack lock files before execution. The same production test passes locally from clean dependency state; the pushed commits rerun GitHub CI.